### PR TITLE
Add Section and Priority Debian control fields

### DIFF
--- a/src/debian/control
+++ b/src/debian/control
@@ -3,5 +3,7 @@ Maintainer: Kamax.io <foss@kamax.io>
 Homepage: https://github.com/kamax-matrix/mxisd
 Description: Federated Matrix Identity Server
 Architecture: all
+Section: misc
+Priority: optional
 Depends: openjdk-8-jre | openjdk-8-jre-headless | openjdk-8-jdk | openjdk-8-jdk-headless
 Version: 0

--- a/src/debian/control
+++ b/src/debian/control
@@ -3,7 +3,7 @@ Maintainer: Kamax.io <foss@kamax.io>
 Homepage: https://github.com/kamax-matrix/mxisd
 Description: Federated Matrix Identity Server
 Architecture: all
-Section: misc
+Section: net
 Priority: optional
 Depends: openjdk-8-jre | openjdk-8-jre-headless | openjdk-8-jdk | openjdk-8-jdk-headless
 Version: 0


### PR DESCRIPTION
The current Debian package doesn't play nicely with repository managers like `reprepro` by default since the `control` file is missing `Section` and `Priority` fields. This PR adds both fields to the Debian control file using basic values to simplify the inclusion of the Debian package in such repositories (or upstream Debian itself eventually).

The priority is set to `optional` as would be expected. The section chosen was `misc` based on `mxisd` not fitting particularly well with [any other section in the current stable](https://packages.debian.org/stable/).